### PR TITLE
Add Markdown Link support for topic changes

### DIFF
--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -110,6 +110,14 @@ chrome.storage.sync.get(['acceptedRisks', 'settings'], res => {
                     }
                     oldListener(e);
                 }
+            } else if (path.match(/\/api\/conversations\.setTopic/)) {
+                const oldSend = this.send.bind(this);
+                this.send = function (e) {
+                    const originalTopic = e.get('topic');
+                    let finalTopic = originalTopic.replace(/\[([^\]]+)\]\(([^\)]+)\)/g, (_, text, url) => `<${url}|${text}>`);
+                    e.set('topic', finalTopic);
+                    oldSend(e);
+                }.bind(this);
             } else if (path.startsWith('/api/chat.postMessage') || path.startsWith('/api/chat.update')) {
                 const oldSend = this.send.bind(this);
                 this.send = function (e) {


### PR DESCRIPTION
First ever modification to a chromium extension.

I love your extension. It gives so much needed configurability to slack.

I tried to copy your style as closely as possible. If the modification should rather be done in the `else if` branch below my point of entry, do tell :)

I _guess_ this doesn't have to be replicated in the websocket section because the topic change should be synchronous.